### PR TITLE
Handle `CMD_ARGS()` returning NULL

### DIFF
--- a/metamod/src/commands_meta.cpp
+++ b/metamod/src/commands_meta.cpp
@@ -60,7 +60,13 @@ void EXT_FUNC server_meta()
 void EXT_FUNC client_meta(edict_t* pEntity)
 {
 	const char *cmd = CMD_ARGV(1);
-	META_LOG("ClientCommand 'meta %s' from player '%s'", CMD_ARGS(), STRING(pEntity->v.netname));
+	const char *args = CMD_ARGS();
+	const char *netname = STRING(pEntity->v.netname);
+
+	if (args == nullptr)
+		META_LOG("ClientCommand 'meta' from player '%s'", netname);
+	else
+		META_LOG("ClientCommand 'meta %s' from player '%s'", args, netname);
 
 	// arguments: none
 	if (!Q_strcmp(cmd, "version"))

--- a/metamod/src/commands_meta.cpp
+++ b/metamod/src/commands_meta.cpp
@@ -113,7 +113,7 @@ void cmd_meta_version()
 		META_CONS("usage: meta version");
 		return;
 	}
-	meta_print_version_info();
+	meta_print_version_info(nullptr);
 }
 
 // "meta version" client command.
@@ -123,7 +123,7 @@ void client_meta_version(edict_t *pEntity)
 		META_CLIENT(pEntity, "usage: meta version");
 		return;
 	}
-	meta_print_version_info();
+	meta_print_version_info(pEntity);
 }
 
 // "meta gpl" console command.

--- a/metamod/src/dllapi.cpp
+++ b/metamod/src/dllapi.cpp
@@ -34,6 +34,7 @@ static void MM_PRE_HOOK mm_ClientCommand(edict_t *pEntity)
 {
 	if (!g_config->m_clientmeta && !Q_strcmp(CMD_ARGV(0), "meta")) {
 		client_meta(pEntity);
+		return;
 	}
 
 	META_DLLAPI_HANDLE_void(FN_CLIENTCOMMAND, pfnClientCommand, (pEntity));

--- a/metamod/src/metamod.cpp
+++ b/metamod/src/metamod.cpp
@@ -57,7 +57,7 @@ void metamod_startup()
 	META_CONS("   This is free software, and you are welcome to redistribute it");
 	META_CONS("   under certain conditions; type `meta gpl' for details.");
 
-	meta_print_version_info();
+	meta_print_version_info(nullptr);
 
 	// Get gamedir, very early on, because it seems we need it all over the
 	// place here at the start.
@@ -447,14 +447,28 @@ bool meta_load_gamedll()
 	return true;
 }
 
-void meta_print_version_info()
+void meta_print_version_info(edict_t *pEntity)
 {
-	META_CONS("   ");
-	META_CONS("Metamod-FWGS version %s", APP_VERSION);
-	META_CONS("Platform     : %s", BuildInfo::GetPlatform());
-	META_CONS("Architecture : %s", BuildInfo::GetArchitecture());
-	META_CONS("Build date   : " __TIME__ " " __DATE__);
-	META_CONS("Commit hash  : " APP_COMMIT_SHA);
-	META_CONS("API version  : " META_INTERFACE_VERSION);
-	META_CONS("   ");
+	if (pEntity)
+	{
+		META_CLIENT(pEntity, "   ");
+		META_CLIENT(pEntity, "Metamod-FWGS version %s", APP_VERSION);
+		META_CLIENT(pEntity, "Platform     : %s", BuildInfo::GetPlatform());
+		META_CLIENT(pEntity, "Architecture : %s", BuildInfo::GetArchitecture());
+		META_CLIENT(pEntity, "Build date   : " __TIME__ " " __DATE__);
+		META_CLIENT(pEntity, "Commit hash  : " APP_COMMIT_SHA);
+		META_CLIENT(pEntity, "API version  : " META_INTERFACE_VERSION);
+		META_CLIENT(pEntity, "   ");
+	}
+	else
+	{
+		META_CONS("   ");
+		META_CONS("Metamod-FWGS version %s", APP_VERSION);
+		META_CONS("Platform     : %s", BuildInfo::GetPlatform());
+		META_CONS("Architecture : %s", BuildInfo::GetArchitecture());
+		META_CONS("Build date   : " __TIME__ " " __DATE__);
+		META_CONS("Commit hash  : " APP_COMMIT_SHA);
+		META_CONS("API version  : " META_INTERFACE_VERSION);
+		META_CONS("   ");
+	}
 }

--- a/metamod/src/metamod.h
+++ b/metamod/src/metamod.h
@@ -90,7 +90,7 @@ void metamod_startup();
 
 bool meta_init_gamedll();
 bool meta_load_gamedll();
-void meta_print_version_info();
+void meta_print_version_info(edict_t *pEntity);
 
 // lotsa macros...
 


### PR DESCRIPTION
If the client sends just "meta", `CMD_ARGS()` returns NULL causing the `META_LOG()` to explode.

Follow-on from https://github.com/FWGS/xash3d-fwgs/pull/2554 + a few extra patches.

https://github.com/FWGS/metamod-fwgs/commit/11b2b1c9fe1153414a08541e08511f15e59f3a44 is the main change - I can drop the other two patches if they're unwanted.