### PR TITLE
metamod/dlls/util: treat offset as signed in STRING()

### DIFF
--- a/metamod/include/dlls/util.h
+++ b/metamod/include/dlls/util.h
@@ -43,7 +43,7 @@
 extern globalvars_t *gpGlobals;
 
 // Use this instead of ALLOC_STRING on constant strings
-#define STRING(offset)		((const char *)(gpGlobals->pStringBase + (unsigned int)(offset)))
+#define STRING(offset)		((const char *)(gpGlobals->pStringBase + (int)(offset)))
 #define MAKE_STRING(str)	((uint64)(str) - (uint64)(STRING(0)))
 
 // Dot products for view cone checking


### PR DESCRIPTION
Fixes crash with "meta" command from a client, e.g. STRING(pEntity->v.netname).

Matches what's in [hlsdk-portable](https://github.com/FWGS/hlsdk-portable/blob/ae84bfc0c3598fcff605a7b3bb963abe8ec3e295/dlls/util.h#L36).


<img width="1052" height="827" alt="Screenshot_20260421_222523" src="https://github.com/user-attachments/assets/0b17e7d4-eb8e-4131-96b8-45e65d27a84f" />
